### PR TITLE
Shopping cart page, Register and Sign in forms

### DIFF
--- a/frontend/src/pages/ShoppingCartPage.tsx
+++ b/frontend/src/pages/ShoppingCartPage.tsx
@@ -1,5 +1,6 @@
 import Button from "../utils/Button";
 import { Link } from "react-router-dom";
+import RegisterForm from "../utils/RegisterForm";
 
 export default function ShoppingCartPage() {
   return (
@@ -18,6 +19,8 @@ export default function ShoppingCartPage() {
           <Button>Sign in</Button>
         </span>
       </div>
+
+      <RegisterForm />
     </div>
   );
 }

--- a/frontend/src/pages/ShoppingCartPage.tsx
+++ b/frontend/src/pages/ShoppingCartPage.tsx
@@ -1,12 +1,13 @@
 import Button from "../utils/Button";
 import { Link } from "react-router-dom";
 import RegisterForm from "../utils/RegisterForm";
+import SigninForm from "../utils/SigninForm";
 
 export default function ShoppingCartPage() {
   return (
     <div className="h-screen bg-red-50">
       ShoppingCartPage
-      <div className="flex gap-5 h-screen flex-col items-center justify-center bg-red-100">
+      <div className="flex h-[70vh] flex-col items-center justify-center gap-5 bg-red-100">
         <h5 className="text-2xl font-semibold">
           You don't have any items in your cart.
         </h5>
@@ -19,8 +20,10 @@ export default function ShoppingCartPage() {
           <Button>Sign in</Button>
         </span>
       </div>
-
-      <RegisterForm />
+      <div className="bg-gray-200 items-center justify-center flex gap-20 ">
+        <RegisterForm />
+        <SigninForm />
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/ShoppingCartPage.tsx
+++ b/frontend/src/pages/ShoppingCartPage.tsx
@@ -1,17 +1,21 @@
+import Button from "../utils/Button";
 import { Link } from "react-router-dom";
 
 export default function ShoppingCartPage() {
   return (
     <div className="h-screen bg-red-50">
       ShoppingCartPage
-      <div className="flex h-screen flex-col items-center justify-center bg-red-100">
+      <div className="flex gap-5 h-screen flex-col items-center justify-center bg-red-100">
         <h5 className="text-2xl font-semibold">
           You don't have any items in your cart.
         </h5>
         <p>Have an account? Sign in to see your items.</p>
         <span className="flex gap-5">
-          <Link to="/">Start shopping</Link>
-          <button>Sign in</button>
+          <Link to="/">
+            <Button>Start shopping</Button>
+          </Link>
+
+          <Button>Sign in</Button>
         </span>
       </div>
     </div>

--- a/frontend/src/utils/Button.tsx
+++ b/frontend/src/utils/Button.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+interface ButtonProps {
+  onClick?: () => void;
+  children: React.ReactNode;
+  className?: string;
+  disabled?: boolean;
+}
+
+const Button: React.FC<ButtonProps> = ({
+  onClick,
+  children,
+  className = "",
+  disabled = false,
+}) => {
+  return (
+    <button
+      onClick={onClick}
+      className={`rounded-full bg-white cursor-pointer border transition border-black px-4 text-lg w-56 py-2.5 text-black hover:bg-gray-200 ${className}`}
+      disabled={disabled}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default Button;

--- a/frontend/src/utils/Button.tsx
+++ b/frontend/src/utils/Button.tsx
@@ -5,6 +5,7 @@ interface ButtonProps {
   children: React.ReactNode;
   className?: string;
   disabled?: boolean;
+  type?: "button" | "submit" | "reset";
 }
 
 const Button: React.FC<ButtonProps> = ({
@@ -12,12 +13,14 @@ const Button: React.FC<ButtonProps> = ({
   children,
   className = "",
   disabled = false,
+  type = "button",
 }) => {
   return (
     <button
       onClick={onClick}
-      className={`rounded-full bg-white cursor-pointer border transition border-black px-4 text-lg w-56 py-2.5 text-black hover:bg-gray-200 ${className}`}
+      className={`rounded-full bg-blue-400 cursor-pointer border transition border-black px-4 text-lg w-56 py-2.5 text-white hover:bg-blue-300 ${className}`}
       disabled={disabled}
+      type={type}
     >
       {children}
     </button>

--- a/frontend/src/utils/RegisterForm.tsx
+++ b/frontend/src/utils/RegisterForm.tsx
@@ -29,6 +29,7 @@ const RegisterForm: React.FC = () => {
     // form submission logic here
     alert("Form submitted");
     console.log("Form submitted", formData);
+    // clear form
     setFormData({
       username: "",
       email: "",
@@ -46,7 +47,7 @@ const RegisterForm: React.FC = () => {
   };
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-100">
+    <div className="flex items-center justify-center">
       <form
         onSubmit={handleSubmit}
         className="w-full max-w-sm rounded bg-white p-6 shadow-md"

--- a/frontend/src/utils/RegisterForm.tsx
+++ b/frontend/src/utils/RegisterForm.tsx
@@ -10,7 +10,40 @@ import {
 import Button from "./Button";
 
 const RegisterForm: React.FC = () => {
-  
+  const [formData, setFormData] = useState({
+    username: "",
+    email: "",
+    password: "",
+    confirmPassword: "",
+  });
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData({ ...formData, [name]: value });
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    // form submission logic here
+    alert("Form submitted");
+    console.log("Form submitted", formData);
+    setFormData({
+      username: "",
+      email: "",
+      password: "",
+      confirmPassword: "",
+    });
+  };
+
+  const togglePasswordVisibility = () => {
+    setShowPassword(!showPassword);
+  };
+
+  const toggleConfirmPasswordVisibility = () => {
+    setShowConfirmPassword(!showConfirmPassword);
+  };
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-100">

--- a/frontend/src/utils/RegisterForm.tsx
+++ b/frontend/src/utils/RegisterForm.tsx
@@ -50,9 +50,9 @@ const RegisterForm: React.FC = () => {
     <div className="flex items-center justify-center">
       <form
         onSubmit={handleSubmit}
-        className="w-full max-w-sm rounded bg-white p-6 shadow-md"
+        className=" w-full rounded bg-white p-10 px-16 shadow-md"
       >
-        <h2 className="mb-6 text-center text-2xl font-bold">Register</h2>
+        <h2 className="mb-6 text-center text-3xl font-semibold">Register</h2>
         <div className="flex flex-col gap-6">
           <div className="relative flex items-center">
             <UserIcon className="mr-3 h-5 w-5 text-gray-400" />
@@ -150,10 +150,7 @@ const RegisterForm: React.FC = () => {
             </label>
           </div>
         </div>
-        <Button
-          type="submit"
-          className="mt-4 w-full rounded bg-blue-500 py-2 text-white transition-colors hover:bg-blue-600"
-        >
+        <Button type="submit" className="mt-10 mx-auto block">
           Register
         </Button>
       </form>

--- a/frontend/src/utils/RegisterForm.tsx
+++ b/frontend/src/utils/RegisterForm.tsx
@@ -1,0 +1,130 @@
+import React, { useState } from "react";
+import {
+  UserIcon,
+  EnvelopeIcon,
+  LockClosedIcon,
+  KeyIcon,
+  EyeIcon,
+  EyeSlashIcon,
+} from "@heroicons/react/20/solid";
+import Button from "./Button";
+
+const RegisterForm: React.FC = () => {
+  
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-100">
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-sm rounded bg-white p-6 shadow-md"
+      >
+        <h2 className="mb-6 text-center text-2xl font-bold">Register</h2>
+        <div className="flex flex-col gap-6">
+          <div className="relative flex items-center">
+            <UserIcon className="mr-3 h-5 w-5 text-gray-400" />
+            <div className="w-full">
+              <input
+                type="text"
+                id="username"
+                name="username"
+                value={formData.username}
+                onChange={handleChange}
+                placeholder="Username"
+                className="w-full rounded border px-3 py-2"
+                required
+              />
+            </div>
+          </div>
+          <div className="relative flex items-center">
+            <EnvelopeIcon className="mr-3 h-5 w-5 text-gray-400" />
+            <div className="w-full">
+              <input
+                type="email"
+                id="email"
+                name="email"
+                value={formData.email}
+                onChange={handleChange}
+                placeholder="Email"
+                className="w-full rounded border px-3 py-2"
+                required
+              />
+            </div>
+          </div>
+          <div className="relative flex items-center">
+            <LockClosedIcon className="mr-3 h-5 w-5 text-gray-400" />
+            <div className="w-full">
+              <div className="relative">
+                <input
+                  type={showPassword ? "text" : "password"}
+                  id="password"
+                  name="password"
+                  value={formData.password}
+                  onChange={handleChange}
+                  placeholder="Password"
+                  className="w-full rounded border px-3 py-2"
+                  required
+                />
+                <div
+                  className="absolute top-1/2 right-3 -translate-y-1/2 transform cursor-pointer text-gray-400"
+                  onClick={togglePasswordVisibility}
+                >
+                  {showPassword ? (
+                    <EyeSlashIcon className="h-5 w-5" />
+                  ) : (
+                    <EyeIcon className="h-5 w-5" />
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+          <div className="relative flex items-center">
+            <KeyIcon className="mr-3 h-5 w-5 text-gray-400" />
+            <div className="w-full">
+              <div className="relative">
+                <input
+                  type={showConfirmPassword ? "text" : "password"}
+                  id="confirmPassword"
+                  name="confirmPassword"
+                  value={formData.confirmPassword}
+                  onChange={handleChange}
+                  placeholder="Confirm Password"
+                  className="w-full rounded border px-3 py-2"
+                  required
+                />
+                <div
+                  className="absolute top-1/2 right-3 -translate-y-1/2 transform cursor-pointer text-gray-400"
+                  onClick={toggleConfirmPasswordVisibility}
+                >
+                  {showConfirmPassword ? (
+                    <EyeSlashIcon className="h-5 w-5" />
+                  ) : (
+                    <EyeIcon className="h-5 w-5" />
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+          <div className="flex items-center">
+            <input
+              type="checkbox"
+              id="agreeToTerms"
+              className="mr-2"
+              required
+            />
+            <label htmlFor="agreeToTerms" className="text-gray-700">
+              I agree to the terms of service
+            </label>
+          </div>
+        </div>
+        <Button
+          type="submit"
+          className="mt-4 w-full rounded bg-blue-500 py-2 text-white transition-colors hover:bg-blue-600"
+        >
+          Register
+        </Button>
+      </form>
+    </div>
+  );
+};
+
+export default RegisterForm;

--- a/frontend/src/utils/SigninForm.tsx
+++ b/frontend/src/utils/SigninForm.tsx
@@ -34,9 +34,9 @@ const SigninForm: React.FC = () => {
     <div className="flex min-h-screen items-center justify-center">
       <form
         onSubmit={handleSubmit}
-        className="w-full max-w-sm rounded bg-white p-6 shadow-md"
+        className="w-full rounded bg-white p-10 px-16 shadow-md"
       >
-        <h2 className="mb-6 text-center text-2xl font-bold">Sign In</h2>
+        <h2 className="mb-6 text-center text-3xl font-semibold">Sign In</h2>
         <div className="flex flex-col gap-6">
           <div className="relative flex items-center">
             <EnvelopeIcon className="h-5 w-5 text-gray-400 mr-3" />
@@ -76,7 +76,7 @@ const SigninForm: React.FC = () => {
         </div>
         <Button
           type="submit"
-          className="mt-4 w-full rounded bg-blue-500 py-2 text-white transition-colors hover:bg-blue-600"
+          className="mt-10 mx-auto block"
         >
           Sign In
         </Button>

--- a/frontend/src/utils/SigninForm.tsx
+++ b/frontend/src/utils/SigninForm.tsx
@@ -1,0 +1,88 @@
+import React, { useState } from "react";
+import { EnvelopeIcon, LockClosedIcon, EyeIcon, EyeSlashIcon } from "@heroicons/react/20/solid";
+import Button from "./Button";
+
+const SigninForm: React.FC = () => {
+  const [formData, setFormData] = useState({
+    email: "",
+    password: "",
+  });
+  const [showPassword, setShowPassword] = useState(false);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData({ ...formData, [name]: value });
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    // form submission logic here
+    alert("Form submitted");
+    console.log("Form submitted", formData);
+    // clear form
+    setFormData({
+      email: "",
+      password: "",
+    });
+  };
+
+  const togglePasswordVisibility = () => {
+    setShowPassword(!showPassword);
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-sm rounded bg-white p-6 shadow-md"
+      >
+        <h2 className="mb-6 text-center text-2xl font-bold">Sign In</h2>
+        <div className="flex flex-col gap-6">
+          <div className="relative flex items-center">
+            <EnvelopeIcon className="h-5 w-5 text-gray-400 mr-3" />
+            <div className="w-full">
+              <input
+                type="email"
+                id="email"
+                name="email"
+                value={formData.email}
+                onChange={handleChange}
+                placeholder="Email"
+                className="w-full rounded border px-3 py-2"
+                required
+              />
+            </div>
+          </div>
+          <div className="relative flex items-center">
+            <LockClosedIcon className="h-5 w-5 text-gray-400 mr-3" />
+            <div className="w-full">
+              <div className="relative">
+                <input
+                  type={showPassword ? "text" : "password"}
+                  id="password"
+                  name="password"
+                  value={formData.password}
+                  onChange={handleChange}
+                  placeholder="Password"
+                  className="w-full rounded border px-3 py-2"
+                  required
+                />
+                <div className="absolute right-3 top-1/2 transform -translate-y-1/2 cursor-pointer text-gray-400" onClick={togglePasswordVisibility}>
+                  {showPassword ? <EyeSlashIcon className="h-5 w-5" /> : <EyeIcon className="h-5 w-5" />}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <Button
+          type="submit"
+          className="mt-4 w-full rounded bg-blue-500 py-2 text-white transition-colors hover:bg-blue-600"
+        >
+          Sign In
+        </Button>
+      </form>
+    </div>
+  );
+};
+
+export default SigninForm;


### PR DESCRIPTION
Changelog, will:

ADD: a register form with basic logic
ADD: a signin form with basic logic
ADD: shopping cart page with the 2 forms living here temporarily. icon on the homepage next to search bar to the right, leads to the shopping cart page 
ADD: reusable button component (with basic styling for now)

_note: initial most basic shopping cart page was accidentaly pushed on dev branch but further updates were in this PR on the right branch._